### PR TITLE
fix: do not clear _missedRef in send() to prevent stuck clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rljson/db",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "packageManager": "pnpm@10.6.3+sha512.bb45e34d50a9a76e858a95837301bfb6bd6d35aea2c5d52094fa497a467c43f5c440103ce2511e9e0a2f89c3d6071baac3358fc68ac6fb75e2ceb3d2736065e6",
   "description": "A high level interface to read and write RLJSON data from and into a database",
   "homepage": "https://github.com/rljson/db",

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -84,9 +84,12 @@ export class Connector {
 
     this._addSentRef(ref);
 
-    // Clear any missed ref — we are sending fresher state, so the
-    // old bootstrap ref is stale and must not be replayed on listen().
-    this._missedRef = null;
+    // Do NOT clear _missedRef here. The bootstrap ref must survive
+    // until listen() is called so the callback receives the server's
+    // latest state. Previously, clearing _missedRef caused a race:
+    // syncToDb's send() would discard the bootstrap, and the
+    // subsequent listen() in syncFromDb would get nothing — leaving
+    // the client permanently stuck.
 
     const payload: ConnectorPayload = {
       o: this._origin,

--- a/test/connector/connector.spec.ts
+++ b/test/connector/connector.spec.ts
@@ -165,7 +165,7 @@ describe('Connector', () => {
       expect(cb2).not.toHaveBeenCalled();
     });
 
-    it('should not replay missed ref after send()', async () => {
+    it('should replay missed ref even after send()', async () => {
       const origin = timeId();
 
       // Bootstrap arrives before any callback
@@ -175,14 +175,17 @@ describe('Connector', () => {
       } as ConnectorPayload;
       socket.emit(route.flat, payload);
 
-      // syncToDb sends fresher state — clears missed ref
+      // syncToDb sends fresher local state — but must NOT discard
+      // the bootstrap. listen() still needs it so syncFromDb can
+      // restore the server's tree.
       connector.send('fresh-local-ref');
 
-      // Now listen() should NOT replay the stale bootstrap
+      // listen() SHOULD replay the bootstrap ref
       const cb = vi.fn();
       connector.listen(cb);
       await new Promise((r) => setTimeout(r, 0));
-      expect(cb).not.toHaveBeenCalled();
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledWith('old-bootstrap-ref');
     });
   });
 


### PR DESCRIPTION
send() previously cleared _missedRef, discarding the bootstrap ref before listen() was called. In production, syncToDb's send() runs before syncFromDb's listen(), causing the client to permanently miss the server's latest tree ref. Bootstrap heartbeats cannot recover because the ref is already in the dedup set.