### PR TITLE
feat(db): explicit predecessor override on insertTrees for merge revisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rljson/db",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "packageManager": "pnpm@10.6.3+sha512.bb45e34d50a9a76e858a95837301bfb6bd6d35aea2c5d52094fa497a467c43f5c440103ce2511e9e0a2f89c3d6071baac3358fc68ac6fb75e2ceb3d2736065e6",
   "description": "A high level interface to read and write RLJSON data from and into a database",
   "homepage": "https://github.com/rljson/db",

--- a/src/db.ts
+++ b/src/db.ts
@@ -1114,7 +1114,11 @@ export class Db {
   async insertTrees(
     treeKey: string,
     trees: Tree[],
-    options?: { skipNotification?: boolean; skipHistory?: boolean },
+    options?: {
+      skipNotification?: boolean;
+      skipHistory?: boolean;
+      previous?: InsertHistoryTimeId[];
+    },
   ): Promise<InsertHistoryRow<any>[]> {
     if (!trees || trees.length === 0) {
       throw new Error(
@@ -1152,6 +1156,15 @@ export class Db {
       ...rootResult,
       route: route.flat,
     };
+
+    // Explicit predecessor override — used to write a merge revision whose
+    // InsertHistory.previous references *both* tips of a forked DAG, collapsing
+    // the fork to a single tip so detectDagBranch stops re-firing. The override
+    // lives only on the InsertHistory row and never affects the tree's content
+    // hash, so the merged tree keeps its natural identity.
+    if (options?.previous) {
+      result.previous = options.previous;
+    }
 
     // Write InsertHistory
     if (!options?.skipHistory) {

--- a/test/db.spec.ts
+++ b/test/db.spec.ts
@@ -2603,6 +2603,39 @@ describe('Db', () => {
       expect(results[0][`${treeKey}Ref`]).toBe(rootHash);
     });
 
+    it('writes a merge revision via the previous override, collapsing a forked DAG', async () => {
+      // Tip A — first revision (root, no predecessor).
+      const aRes = await treeDb.insertTrees(treeKey, treeFromObject({ a: 1 }));
+      const tA = aRes[0].timeId;
+
+      // Tip B — force previous=[] so it does NOT chain onto A, producing a
+      // genuine two-tip fork in the InsertHistory DAG.
+      const bRes = await treeDb.insertTrees(treeKey, treeFromObject({ b: 2 }), {
+        previous: [],
+      });
+      const tB = bRes[0].timeId;
+
+      const fork = await treeDb.detectDagBranch(treeKey);
+      expect(fork?.type).toBe('dagBranch');
+      expect([...(fork?.branches ?? [])].sort()).toEqual([tA, tB].sort());
+
+      // Merge revision D references BOTH tips → both become referenced parents,
+      // collapsing the fork back to a single tip.
+      const dRes = await treeDb.insertTrees(
+        treeKey,
+        treeFromObject({ merged: 3 }),
+        { previous: [tA, tB] },
+      );
+      const historyRow = await treeDb.getInsertHistoryRowByTimeId(
+        treeKey,
+        dRes[0].timeId,
+      );
+      expect(historyRow.previous).toEqual([tA, tB]);
+
+      // Fork is gone — single tip again.
+      expect(await treeDb.detectDagBranch(treeKey)).toBeNull();
+    });
+
     it('should produce same ref as db.core.import for identical data', async () => {
       const treeObject = {
         fileX: 'contentX',


### PR DESCRIPTION
## What
`insertTrees` gains an optional `previous?: InsertHistoryTimeId[]` option. When provided, it overrides the InsertHistory row's predecessor list, allowing callers to write a **merge revision** referencing *both* tips of a forked DAG — collapsing the fork to a single tip so `detectDagBranch` stops re-firing.

## Why
Required for Nextcloud-style offline-edit conflict resolution in `@rljson/fs-agent` (revision D with `previous=[tipB, tipC]`). See `rljson-fs-agent/doc/conflict-resolution-design.md` §4.4.

## Safety
- **Additive**: when `previous` is unset, behaviour is byte-identical to before.
- The override lives only on the InsertHistory row — it never touches the tree's content hash, so merged trees keep their natural identity.

## Tests
New test forces a genuine two-tip fork via `{ previous: [] }`, asserts `detectDagBranch` reports it, writes a merge revision with `{ previous: [tA, tB] }`, and asserts the fork collapses (single tip, `detectDagBranch → null`). Full suite 425 passing, 100% coverage, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)