### PR TITLE
feat(connector): invalidateReceived for heartbeat re-delivery (0.0.23)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rljson/db",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "packageManager": "pnpm@10.6.3+sha512.bb45e34d50a9a76e858a95837301bfb6bd6d35aea2c5d52094fa497a467c43f5c440103ce2511e9e0a2f89c3d6071baac3358fc68ac6fb75e2ceb3d2736065e6",
   "description": "A high level interface to read and write RLJSON data from and into a database",
   "homepage": "https://github.com/rljson/db",

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -214,6 +214,25 @@ export class Connector {
 
   // ...........................................................................
   /**
+   * Removes a ref from the received-dedup set so a later re-advertisement of
+   * the same ref (e.g. the server's bootstrap heartbeat, which only re-sends
+   * the *latest* ref) is delivered to listeners again instead of being
+   * silently deduplicated.
+   *
+   * A ref is added to the dedup set the instant it is *received* — before the
+   * listener callback (which materializes it) has a chance to succeed. If that
+   * apply step fails terminally, the ref is stuck in the dedup set forever and
+   * the heartbeat can never heal it. Consumers whose apply failed call this so
+   * recovery becomes eventually-consistent rather than permanent loss.
+   * @param ref - The ref to allow re-delivery for.
+   */
+  invalidateReceived(ref: string): void {
+    this._receivedRefsCurrent.delete(ref);
+    this._receivedRefsPrevious.delete(ref);
+  }
+
+  // ...........................................................................
+  /**
    * Returns the current sequence number.
    * Only meaningful when `causalOrdering` is enabled.
    */

--- a/test/connector/connector.spec.ts
+++ b/test/connector/connector.spec.ts
@@ -236,6 +236,48 @@ describe('Connector', () => {
     });
   });
 
+  describe('invalidateReceived', () => {
+    it('allows a received ref to be re-delivered (heartbeat recovery)', async () => {
+      const callback = vi.fn();
+      const origin = timeId();
+      connector.listen(callback);
+
+      const payload = {
+        r: editHistory._hash,
+        o: origin,
+      } as ConnectorPayload;
+
+      // First delivery — callback fires, ref enters the received-dedup set.
+      socket.emit(route.flat, payload);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      // A re-advertisement (e.g. the server's bootstrap heartbeat re-sending
+      // the latest ref) is suppressed as a duplicate — this is what makes a
+      // failed apply permanent.
+      socket.emit(route.flat, payload);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      // After invalidating, the same ref is delivered again so the heartbeat
+      // can re-trigger the apply once the transient condition clears.
+      connector.invalidateReceived(editHistory._hash);
+      socket.emit(route.flat, payload);
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it('is a no-op for a ref that was never received', () => {
+      // Must not throw and must not affect later delivery of a fresh ref.
+      expect(() => connector.invalidateReceived('never-seen-ref')).not.toThrow();
+
+      const callback = vi.fn();
+      connector.listen(callback);
+      socket.emit(route.flat, {
+        r: editHistory._hash,
+        o: timeId(),
+      } as ConnectorPayload);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('registerDbObserver', () => {
     it('should register Db observer for new EditHistory additions', async () => {
       const callback = vi.fn();


### PR DESCRIPTION
## Why
4-node sync propagation was intermittently/permanently dropping refs. Root cause (one of two reinforcing defects): a ref enters the receiver's dedup set the instant it arrives — *before* the listener callback materializes it. If the apply fails terminally (e.g. FsAgent recovery budget exhausted on a transient blob-pull failure), the ref stays in the dedup set forever, so the server's bootstrap heartbeat (which only re-advertises the latest ref) is suppressed as a duplicate and can never re-trigger the failed apply.

## What
New public `Connector.invalidateReceived(ref)`: removes a ref from the received-dedup set so a later re-advertisement is delivered again. Consumers whose apply failed call it to convert permanent loss into eventually-consistent recovery (the FsAgent side lands in `@rljson/fs-agent` 0.0.16).

## Tests
Two regression tests in `connector.spec.ts` (re-delivery after invalidate; no-op safety for never-received refs). Full suite green, 100% coverage.

Bump 0.0.22 → 0.0.23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)